### PR TITLE
python-igraph was renamed to igraph

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-python-igraph==0.8.2
+igraph==0.9.8
 antlr4-python3-runtime==4.8

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     long_description_content_type='text/x-rst',
     url='https://github.com/SkyTemple/ExplorerScript/',
     install_requires=[
-        'python-igraph >= 0.8.0',
+        'igraph >= 0.8.0',
         'antlr4-python3-runtime == 4.8'
     ],
     extras_require={


### PR DESCRIPTION
https://igraph.org/2021/10/29/igraph-0.9.8-python.html