### PR TITLE
Fix offset rewriting

### DIFF
--- a/explorerscript/source_map.py
+++ b/explorerscript/source_map.py
@@ -271,17 +271,19 @@ class SourceMap:
         # but that's ok.
         self._mappings = {new_mapping[key]: val for key, val in self._mappings.items() if key in new_mapping}
         self._mappings_macros = {new_mapping[key]: val for key, val in self._mappings_macros.items() if key in new_mapping}
+        max_old_offset = max(new_mapping.keys())
+
         for m in self._mappings_macros.values():
             if m.return_addr:
                 addr = m.return_addr
                 while addr not in new_mapping:
                     # if the return addr opcode was optimized away, we take the next index. TODO: Good idea?
                     addr += 1
-                    if addr > len(self._mappings):
+                    if addr > max_old_offset:
                         addr = None
                         break
                 if addr is not None:
-                    m.return_addr = new_mapping[m.return_addr]
+                    m.return_addr = new_mapping[addr]
 
 
 class SourceMapBuilder:


### PR DESCRIPTION
Recently reported at: https://discord.com/channels/710190644152369162/787260430728691712/921138547388452905

Seems like there were a couple of problems with the way offsets were rewritten, which sometimes caused an error when trying to save scripts that contained macro calls. Those scripts compile successfully and work as they should after applying the fix.

I can't say for sure that the logic of the method is 100% correct (the output works but seems overcomplicated, see Discord thread for details), but at least it works I guess.

Fixes #8.