### PR TITLE
Try linking libsystem statically

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,10 @@ if(APPLE)
     else()
         message(WARNING "Homebrew LLVM not found. Using system default, this might or might not work.")
     endif()
+
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -static")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static")
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -static")
 endif()
 
 if(MSVC)


### PR DESCRIPTION
An attempt to fix
```
ImportError: dlopen(/Applications/SkyTemple.app/Contents/Frameworks/explorerscript_parser.cpython-312-darwin.so, 0x0002): symbol not found in flat namespace '__ZN6antlr410Recognizer12getTokenTypeENSt3__117basic_string_viewIcNS1_11char_traitsIcEEEE'
[79374] Failed to execute script 'main' due to unhandled exception: dlopen(/Applications/SkyTemple.app/Contents/Frameworks/explorerscript_parser.cpython-312-darwin.so, 0x0002): symbol not found in flat namespace '__ZN6antlr410Recognizer12getTokenTypeENSt3__117basic_string_viewIcNS1_11char_traitsIcEEEE'
```